### PR TITLE
未ログイン状態でいいね操作が許可されていない状態をトップページの素材のStateに反映

### DIFF
--- a/components/molecules/MaterialItem.tsx
+++ b/components/molecules/MaterialItem.tsx
@@ -4,6 +4,10 @@ import { color, curve, font, media, zIndex } from '../../styles'
 import Link from 'next/link'
 import Image from 'next/image'
 
+// いいねボタンの状態を表すType
+// 'NOT_UPVOTED' => いいね前 / 'UPVOTED' => いいね済 / 'NOT_PERMITTED' => 未ログインなのでいいね操作が許可されていない
+type UpvoteButtonState = 'NOT_UPVOTED' | 'UPVOTED' | 'NOT_PERMITTED'
+
 type Props = {
   plasticImageUrl: string
   keycapImageUrl: string
@@ -13,7 +17,7 @@ type Props = {
   plasticType: string
   celsius: number
   goodCount: number
-  upvotableMaterials: string[]
+  upvoteButtonState: UpvoteButtonState
   upvote: Function
 }
 
@@ -26,7 +30,7 @@ export const MaterialItem: React.VFC<Props> = ({
   celsius,
   plasticType,
   goodCount,
-  upvotableMaterials,
+  upvoteButtonState,
   upvote,
 }) => {
   return (
@@ -70,8 +74,8 @@ export const MaterialItem: React.VFC<Props> = ({
                 event.stopPropagation()
                 upvote(id)
               }}
-              disabled={!upvotableMaterials.includes(id)}
-            ></UpvoteButton>
+              disabled={upvoteButtonState === 'UPVOTED' || upvoteButtonState === 'NOT_PERMITTED'}
+            />
             <span>{goodCount}</span>
           </UpvoteButtonWrap>
         </InfoWrap>

--- a/components/organisms/Home.tsx
+++ b/components/organisms/Home.tsx
@@ -22,11 +22,18 @@ import { useTranslation } from 'next-i18next'
 type Props = {
   materials: Material[]
   setGoodCount: (materialId: string, count: number) => void
-  upvotableMaterials: string[]
+  canUpvote: boolean
+  upvotedMaterialsId: string[]
   upvote: Function
 }
 
-export const Home: React.VFC<Props> = ({ materials, setGoodCount, upvotableMaterials, upvote }) => {
+export const Home: React.VFC<Props> = ({
+  materials,
+  setGoodCount,
+  canUpvote,
+  upvotedMaterialsId,
+  upvote,
+}) => {
   const authStatus = useContext(AuthContext)
   const { currentUser } = getAuth()
   const sliderSettings = {
@@ -387,7 +394,13 @@ export const Home: React.VFC<Props> = ({ materials, setGoodCount, upvotableMater
                         celsius={material.celsius}
                         plasticType={material.plasticType}
                         goodCount={material.goodCount}
-                        upvotableMaterials={upvotableMaterials}
+                        upvoteButtonState={
+                          canUpvote
+                            ? upvotedMaterialsId.includes(material.id)
+                              ? 'UPVOTED'
+                              : 'NOT_UPVOTED'
+                            : 'NOT_PERMITTED'
+                        }
                         upvote={upvote}
                       />
                     ))}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,7 +26,7 @@ export const Index: NextPage<Props> = (_) => {
   const authState = useContext(AuthContext)
   const currentUser = getAuth().currentUser
 
-  const [upvotableMaterials, setUpvotableMaterials] = useState<string[]>([])
+  const [upvotedMaterials, setUpvotedMaterials] = useState<string[]>([])
   const [materials, setMaterials] = useState<Material[]>([])
 
   // 認証の初期化が完了し、ログイン状態が変化した時にキーキャップ素材データを取得する処理
@@ -36,9 +36,9 @@ export const Index: NextPage<Props> = (_) => {
       if (authState === 'LOGGED_IN' && currentUser) {
         const fetchResult = await fetchMaterialsWithAuth()
         setMaterials(fetchResult.materials)
-        setUpvotableMaterials(
+        setUpvotedMaterials(
           fetchResult.materials
-            .filter((material) => !fetchResult.alreadyUpvoted.includes(material.id))
+            .filter((material) => fetchResult.alreadyUpvoted.includes(material.id))
             .map((material) => material.id)
         )
       } else if (authState === 'NOT_LOGIN') {
@@ -48,7 +48,7 @@ export const Index: NextPage<Props> = (_) => {
             .then((res) => res.data)
           data = response.materials!
           setMaterials(data)
-          setUpvotableMaterials([])
+          setUpvotedMaterials([])
         } catch (e) {
           if (Axios.isAxiosError(e) && e.response) {
             console.log(e)
@@ -83,7 +83,7 @@ export const Index: NextPage<Props> = (_) => {
    */
   const upvote = async (materialId: string) => {
     // 二重送信・既にUpvote済みの素材に対する再送信の防止
-    if (!upvotableMaterials.includes(materialId)) {
+    if (upvotedMaterials.includes(materialId)) {
       return
     }
 
@@ -92,7 +92,7 @@ export const Index: NextPage<Props> = (_) => {
       return
     }
 
-    setUpvotableMaterials(upvotableMaterials.filter((item) => item !== materialId))
+    setUpvotedMaterials([materialId, ...upvotedMaterials])
 
     const idToken = await currentUser.getIdToken(true)
 
@@ -131,7 +131,8 @@ export const Index: NextPage<Props> = (_) => {
       <Home
         materials={materials || []}
         setGoodCount={setGoodCount}
-        upvotableMaterials={upvotableMaterials}
+        canUpvote={authState === 'LOGGED_IN'}
+        upvotedMaterialsId={upvotedMaterials}
         upvote={upvote}
       />
     </>


### PR DESCRIPTION
いいねボタンをdisabledにする条件が、「いいね済みである」場合と「ログインしていないのでいいね操作が許可されていない」場合でごっちゃになっていたので、`MaterialItem.tsx` のPropでどちらの状態であるのかが判別できるようにしました。

- `MaterialItem`のpropsに`upvoteButtonState` を追加
	- 'NOT_UPVOTED' の場合はいいね操作をする前
	- 'UPVOTED' の場合はいいね済み
	- 'NOT_PERMITTED' の場合は未ログイン状態なのでいいね操作が許可されていない

です。